### PR TITLE
Remove dependency on configurable (and removable) alias definitions

### DIFF
--- a/src/Xinax/LaravelGettext/Adapters/LaravelAdapter.php
+++ b/src/Xinax/LaravelGettext/Adapters/LaravelAdapter.php
@@ -2,6 +2,8 @@
 
 namespace Xinax\LaravelGettext\Adapters;
 
+use Illuminate\Support\Facades\App;
+
 class LaravelAdapter implements AdapterInterface
 {
 
@@ -10,7 +12,7 @@ class LaravelAdapter implements AdapterInterface
      */
     public function setLocale($locale)
     {
-        \App::setLocale(substr($locale, 0, 2));
+        App::setLocale(substr($locale, 0, 2));
     }
 
     /**
@@ -18,7 +20,7 @@ class LaravelAdapter implements AdapterInterface
      */
     public function getLocale()
     {
-        return \App::getLocale();
+        return App::getLocale();
     }
 
     /**

--- a/src/Xinax/LaravelGettext/Composers/LanguageSelector.php
+++ b/src/Xinax/LaravelGettext/Composers/LanguageSelector.php
@@ -1,7 +1,7 @@
 <?php namespace Xinax\LaravelGettext\Composers;
 
 use Xinax\LaravelGettext\LaravelGettext;
-use \Config;
+use Illuminate\Support\Facades\Config;
 
 /**
  * Simple language selector generator.

--- a/src/Xinax/LaravelGettext/Config/ConfigManager.php
+++ b/src/Xinax/LaravelGettext/Config/ConfigManager.php
@@ -5,7 +5,7 @@ namespace Xinax\LaravelGettext\Config;
 use \Xinax\LaravelGettext\Config\Models\Config as ConfigModel;
 use \Xinax\LaravelGettext\Exceptions\RequiredConfigurationFileException;
 use \Xinax\LaravelGettext\Exceptions\RequiredConfigurationKeyException;
-use \Config;
+use \Illuminate\Support\Facades\Config;
 
 class ConfigManager
 {

--- a/src/Xinax/LaravelGettext/Gettext.php
+++ b/src/Xinax/LaravelGettext/Gettext.php
@@ -7,7 +7,7 @@ use Xinax\LaravelGettext\Adapters\AdapterInterface;
 use Xinax\LaravelGettext\Config\Models\Config;
 use Xinax\LaravelGettext\Exceptions\UndefinedDomainException;
 
-use \Session;
+use Illuminate\Support\Facades\Session;
 
 class Gettext
 {

--- a/src/Xinax/LaravelGettext/Session/SessionHandler.php
+++ b/src/Xinax/LaravelGettext/Session/SessionHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace Xinax\LaravelGettext\Session;
-use \Session;
+use Illuminate\Support\Facades\Session;
 
 class SessionHandler{
 


### PR DESCRIPTION
By making the used facade references explicit the component no longer has a dependency on the alias definitions in app.php.

I'd appreciate it if you could pull this in, because we like to keep the alias definitions disabled to ensure no aliases are used while coding our app. Thanks!