### PR TITLE
Made the session identifier configurable

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# top-most EditorConfig file
+root = true
+
+[*.{php,yml,json,xml}]
+end_of_line = LF
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /public
 composer.phar
 composer.lock
+.idea
 .DS_Store
 doc/poedit-fw.png
 tests/lang/*

--- a/src/Xinax/LaravelGettext/Composers/LanguageSelector.php
+++ b/src/Xinax/LaravelGettext/Composers/LanguageSelector.php
@@ -5,78 +5,78 @@ use Illuminate\Support\Facades\Config;
 
 /**
  * Simple language selector generator.
- * @author Nicolás Daniel Palumbo 
+ * @author Nicolás Daniel Palumbo
  */
 class LanguageSelector
 {
 
-	/**
-	 * Language labels
-	 * @var Array
-	 */
-	protected $labels = [];
+    /**
+     * Language labels
+     * @var Array
+     */
+    protected $labels = [];
 
-	/**
-	 * Laravel gettext wrapper
-	 * @var LaravelGettext
-	 */
-	protected $gettext;
+    /**
+     * Laravel gettext wrapper
+     * @var LaravelGettext
+     */
+    protected $gettext;
 
-	/**
-	 * Creates a new instance of language selector
-	 * @param Array $labels 
-	 */		
-	public function __construct($labels = [], LaravelGettext $gettext)
-	{
-		$this->labels = $labels;
-		$this->gettext = $gettext;
-	}
+    /**
+     * Creates a new instance of language selector
+     * @param Array $labels
+     */
+    public function __construct($labels = [], LaravelGettext $gettext)
+    {
+        $this->labels = $labels;
+        $this->gettext = $gettext;
+    }
 
-	/**
-	 * Creates a new selector instance
-	 * @return void 
-	 */
-	public static function create($labels = [], LaravelGettext $gettext)
-	{
-		return new LanguageSelector($labels, $gettext);
-	}
+    /**
+     * Creates a new selector instance
+     * @return void
+     */
+    public static function create($labels = [], LaravelGettext $gettext)
+    {
+        return new LanguageSelector($labels, $gettext);
+    }
 
-	/**
-	 * Renders the language selector
-	 * @return String 
-	 */
-	public function render()
-	{
-		$html = '<ul class="language-selector">';
+    /**
+     * Renders the language selector
+     * @return String
+     */
+    public function render()
+    {
+        $html = '<ul class="language-selector">';
 
-		foreach (Config::get('laravel-gettext.supported-locales') as $locale) {
+        foreach (Config::get('laravel-gettext.supported-locales') as $locale) {
 
-			if(count($this->labels) && array_key_exists($locale, $this->labels)){
-				$localeLabel = $this->labels[$locale];
-			} else {
-				$localeLabel = $locale;
-			}
-			
-			if($locale == $this->gettext->getLocale()){
-				$html .= '<li><strong class="active ' . $locale . '">' . $localeLabel . '</strong></li>';
-			} else {
-				$html .= '<li><a href="/lang/' . $locale . '" class="' . $locale . '">' . $localeLabel . '</a></li>';
-			}
+            if(count($this->labels) && array_key_exists($locale, $this->labels)){
+                $localeLabel = $this->labels[$locale];
+            } else {
+                $localeLabel = $locale;
+            }
 
-		}
+            if($locale == $this->gettext->getLocale()){
+                $html .= '<li><strong class="active ' . $locale . '">' . $localeLabel . '</strong></li>';
+            } else {
+                $html .= '<li><a href="/lang/' . $locale . '" class="' . $locale . '">' . $localeLabel . '</a></li>';
+            }
 
-		$html .= '</ul>';
+        }
 
-		return $html;
-	}
+        $html .= '</ul>';
 
-	/**
-	 * String conversion
-	 * @return string 
-	 */
-	public function __toString()
-	{
-		return $this->render();
-	}
+        return $html;
+    }
+
+    /**
+     * String conversion
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->render();
+    }
 
 }

--- a/src/Xinax/LaravelGettext/Config/ConfigManager.php
+++ b/src/Xinax/LaravelGettext/Config/ConfigManager.php
@@ -83,6 +83,7 @@ class ConfigManager
 
         $container = new ConfigModel();
         $container->setLocale($config['locale'])
+            ->setSessionIdentifier(isset($config['session-identifier']) ? $config['session-identifier'] : 'laravel-gettext-locale')
             ->setEncoding($config['encoding'])
             ->setFallbackLocale($config['fallback-locale'])
             ->setSupportedLocales($config['supported-locales'])

--- a/src/Xinax/LaravelGettext/Config/Models/Config.php
+++ b/src/Xinax/LaravelGettext/Config/Models/Config.php
@@ -6,6 +6,13 @@ class Config
 {
 
     /**
+     * Session identifier
+     *
+     * @type String
+     */
+    protected $sessionIdentifier;
+
+    /**
      * Charset encoding for files (UTF-8)
      *
      * @type
@@ -74,6 +81,28 @@ class Config
      * @type Boolean
      */
     protected $syncLaravel;
+
+    /**
+     * Gets the session identifier.
+     *
+     * @return mixed
+     */
+    public function getSessionIdentifier()
+    {
+        return $this->sessionIdentifier;
+    }
+
+    /**
+     * Sets the session identifier.
+     *
+     * @param mixed $identifier the identifier
+     * @return self
+     */
+    public function setSessionIdentifier($identifier)
+    {
+        $this->encoding = $identifier;
+        return $this;
+    }
 
     /**
      * Gets the Charset encoding for files (UTF-8).

--- a/src/Xinax/LaravelGettext/FileSystem.php
+++ b/src/Xinax/LaravelGettext/FileSystem.php
@@ -9,7 +9,7 @@ class FileSystem {
 
     /**
      * Package configuration model
-     * 
+     *
      * @var Config
      */
     protected $configuration;
@@ -17,28 +17,28 @@ class FileSystem {
     /**
      * File system base path
      * All paths will be relative to this
-     * 
+     *
      * @var String
      */
     protected $basePath;
 
     /**
      * Storage path for file generation
-     * 
+     *
      * @var String
      */
     protected $storagePath;
 
     /**
      * Storage directory name for view compilation
-     * 
+     *
      * @var String
      */
     protected $storageContainer;
 
     /**
      * Sets configuration
-     * 
+     *
      * @param Config $config
      * @param String $basePath
      * @param String $storagePath
@@ -56,7 +56,7 @@ class FileSystem {
      *
      * @param Array $viewPaths
      * @param String $domain
-     * 
+     *
      * @return Boolean status
      */
     public function compileViews(Array $viewPaths, $domain)
@@ -82,7 +82,7 @@ class FileSystem {
             $compiler = new \Illuminate\View\Compilers\BladeCompiler($fs, $domainDir);
 
             foreach ($files as $file) {
-				$filePath = $file->getRealPath();
+                $filePath = $file->getRealPath();
                 $compiler->setPath($filePath);
                 $contents = $compiler->compileString($fs->get($filePath));
                 $compiledPath = $compiler->getCompiledPath($compiler->getPath());
@@ -162,7 +162,7 @@ class FileSystem {
 
             // View compilation
             $this->compileViews($sourcePaths, $domain);
-            array_push($sourcePaths, $this->getStorageForDomain($domain));    
+            array_push($sourcePaths, $this->getStorageForDomain($domain));
 
             $i = 0;
             foreach ($sourcePaths as $sourcePath) {
@@ -245,7 +245,7 @@ class FileSystem {
      * @param  String                      $locale
      * @param  String                      $domain
      * @throws LocaleFileNotFoundException
-     * @return Boolean 
+     * @return Boolean
      */
     public function updateLocale($localePath, $locale, $domain)
     {
@@ -273,16 +273,16 @@ class FileSystem {
 
         return true;
 
-    }    
+    }
 
-   /**
-    * Return the relative path from a file or directory to another
-    *
-    * @param    String          $from
-    * @param    String          $to
-    * @return   String          $path
-    * @author   Laurent Goussard
-    **/
+    /**
+     * Return the relative path from a file or directory to another
+     *
+     * @param    String          $from
+     * @param    String          $to
+     * @return   String          $path
+     * @author   Laurent Goussard
+     **/
     public function getRelativePath($from, $to)
     {
         // some compatibility fixes for Windows paths
@@ -331,7 +331,7 @@ class FileSystem {
         // Application base path
         if (!file_exists($this->basePath)) {
             throw new Exceptions\DirectoryNotFoundException(
-                "Missing root path directory: " . $this->basePath . 
+                "Missing root path directory: " . $this->basePath .
                 ", check the 'base-path' key in your configuration."
             );
         }
@@ -370,8 +370,8 @@ class FileSystem {
 
     /**
      * Creates the localization directories and files, by domain
-     * Returns an array with all created paths  
-     * 
+     * Returns an array with all created paths
+     *
      * @return Array paths
      */
     public function generateLocales()
@@ -471,26 +471,26 @@ class FileSystem {
 
     /**
      * Returns the full path for a domain storage directory
-     * 
+     *
      * @param  String $domain
      * @return String
      */
     public function getStorageForDomain($domain)
     {
-        $domainPath = $this->storagePath . 
-                        DIRECTORY_SEPARATOR .
-                        $this->storageContainer . 
-                        DIRECTORY_SEPARATOR .
-                        $domain;
+        $domainPath = $this->storagePath .
+            DIRECTORY_SEPARATOR .
+            $this->storageContainer .
+            DIRECTORY_SEPARATOR .
+            $domain;
 
         return $this->getRelativePath($this->basePath, $domainPath);
     }
 
     /**
      * Removes the directory contents recursively
-     * 
-     * @param  String $path 
-     * @return void       
+     *
+     * @param  String $path
+     * @return void
      */
     public static function clearDirectory($path)
     {

--- a/src/Xinax/LaravelGettext/Gettext.php
+++ b/src/Xinax/LaravelGettext/Gettext.php
@@ -13,7 +13,7 @@ class Gettext
 {
     /**
      * Config container
-     * @type Xinax\LaravelGettext\Config\Models\Config
+     * @type \Xinax\LaravelGettext\Config\Models\Config
      */
     protected $configuration;
 
@@ -31,7 +31,7 @@ class Gettext
 
     /**
      * Framework adapter
-     * @type Xinax\Adapters\LaravelAdapter
+     * @type \Xinax\Adapters\LaravelAdapter
      */
     protected $adapter;
 

--- a/src/Xinax/LaravelGettext/LaravelGettextServiceProvider.php
+++ b/src/Xinax/LaravelGettext/LaravelGettextServiceProvider.php
@@ -46,7 +46,7 @@ class LaravelGettextServiceProvider extends ServiceProvider
 
             $gettext = new Gettext(
                 $configuration->get(),
-                new Session\SessionHandler,
+                new Session\SessionHandler($configuration->get()->getSessionIdentifier()),
                 new Adapters\LaravelAdapter,
                 $fileSystem
             );

--- a/src/Xinax/LaravelGettext/Session/SessionHandler.php
+++ b/src/Xinax/LaravelGettext/Session/SessionHandler.php
@@ -5,33 +5,33 @@ use Illuminate\Support\Facades\Session;
 
 class SessionHandler{
 
-	/**
-	 * Session identifier to store active locale 
-	 */
-	const SESSION_IDENTIFIER = "laravel-gettext-locale";
+    /**
+     * Session identifier to store active locale
+     */
+    const SESSION_IDENTIFIER = "laravel-gettext-locale";
 
-	/**
-	 * Returns the locale identifier from 
-	 * the main session adapter
-	 */
-	public function get($default)
+    /**
+     * Returns the locale identifier from
+     * the main session adapter
+     */
+    public function get($default)
     {
 
-		$locale = $default;
-		
-		if(Session::has(self::SESSION_IDENTIFIER)){
-			$locale = Session::get(self::SESSION_IDENTIFIER);
-		}
+        $locale = $default;
 
-		return $locale;
+        if(Session::has(self::SESSION_IDENTIFIER)){
+            $locale = Session::get(self::SESSION_IDENTIFIER);
+        }
 
-	}
+        return $locale;
 
-	/**
-	 * Sets the given locale on session
-	 */	
-	public function set($locale)
+    }
+
+    /**
+     * Sets the given locale on session
+     */
+    public function set($locale)
     {
-		Session::set(self::SESSION_IDENTIFIER, $locale);
-	}
+        Session::set(self::SESSION_IDENTIFIER, $locale);
+    }
 }

--- a/src/Xinax/LaravelGettext/Session/SessionHandler.php
+++ b/src/Xinax/LaravelGettext/Session/SessionHandler.php
@@ -1,14 +1,22 @@
 <?php
 
 namespace Xinax\LaravelGettext\Session;
+
 use Illuminate\Support\Facades\Session;
 
 class SessionHandler{
 
+    private $sessionIdentifier;
+
     /**
-     * Session identifier to store active locale
+     * Creates a new Session handler.
+     *
+     * @param string $sessionIdentifier The identifier
      */
-    const SESSION_IDENTIFIER = "laravel-gettext-locale";
+    public function __construct($sessionIdentifier)
+    {
+        $this->sessionIdentifier = $sessionIdentifier;
+    }
 
     /**
      * Returns the locale identifier from
@@ -19,8 +27,8 @@ class SessionHandler{
 
         $locale = $default;
 
-        if(Session::has(self::SESSION_IDENTIFIER)){
-            $locale = Session::get(self::SESSION_IDENTIFIER);
+        if(Session::has($this->sessionIdentifier)){
+            $locale = Session::get($this->sessionIdentifier);
         }
 
         return $locale;
@@ -32,6 +40,6 @@ class SessionHandler{
      */
     public function set($locale)
     {
-        Session::set(self::SESSION_IDENTIFIER, $locale);
+        Session::set($this->sessionIdentifier, $locale);
     }
 }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -3,6 +3,11 @@
 return array(
 
     /**
+     * Session identifier: Key under which the current locale will be stored.
+     */
+    'session-identifier' => 'laravel-gettext-locale',
+
+    /**
      * Default locale: this will be the default for your application.
      * Is to be supposed that all strings are written in this language.
      */

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -2,75 +2,75 @@
 
 return array(
 
-	/**
-	 * Default locale: this will be the default for your application. 
-	 * Is to be supposed that all strings are written in this language.
-	 */
-	'locale' => 'en_US',
+    /**
+     * Default locale: this will be the default for your application.
+     * Is to be supposed that all strings are written in this language.
+     */
+    'locale' => 'en_US',
 
-	/**
-	 * Supported locales: An array containing all allowed languages
-	 */
-	'supported-locales' => array(
-		'en_US',
-	),	
+    /**
+     * Supported locales: An array containing all allowed languages
+     */
+    'supported-locales' => array(
+        'en_US',
+    ),
 
-	/**
-	 * Default charset encoding.
-	 */
-	'encoding' => 'UTF-8',
+    /**
+     * Default charset encoding.
+     */
+    'encoding' => 'UTF-8',
 
-	/**
-	 * -----------------------------------------------------------------------
-	 * All standard configuration ends here. The following values 
-	 * are only for special cases.
-	 * -----------------------------------------------------------------------
-	 **/
+    /**
+     * -----------------------------------------------------------------------
+     * All standard configuration ends here. The following values
+     * are only for special cases.
+     * -----------------------------------------------------------------------
+     **/
 
     /**
      * Base translation directory path (don't use trailing slash)
      */
     'translations-path' => '../resources/lang',
 
-	/**
-	 * Fallback locale: When default locale is not available
-	 */
-	'fallback-locale' => 'en_US',
+    /**
+     * Fallback locale: When default locale is not available
+     */
+    'fallback-locale' => 'en_US',
 
-	/**
-	 * Default domain used for translations: It is the file name for .po and .mo files
-	 */
-	'domain' => 'messages',
+    /**
+     * Default domain used for translations: It is the file name for .po and .mo files
+     */
+    'domain' => 'messages',
 
-	/**
-	 * Project name: is used on .po header files 
-	 */
-	'project' => 'MultilanguageLaravelApplication',
+    /**
+     * Project name: is used on .po header files
+     */
+    'project' => 'MultilanguageLaravelApplication',
 
-	/**
-	 * Translator contact data (used on .po headers too)
-	 */
-	'translator' => 'James Translator <james@translations.colm>',
+    /**
+     * Translator contact data (used on .po headers too)
+     */
+    'translator' => 'James Translator <james@translations.colm>',
 
-	/**
-	 * Paths where PoEdit will search recursively for strings to translate. 
-	 * All paths are relative to app/ (don't use trailing slash).
-	 *
-	 * Remember to call artisan gettext:update after change this.
-	 */
-	'source-paths' => array(
+    /**
+     * Paths where PoEdit will search recursively for strings to translate.
+     * All paths are relative to app/ (don't use trailing slash).
+     *
+     * Remember to call artisan gettext:update after change this.
+     */
+    'source-paths' => array(
         'Http/Controllers',
         '../resources/views',
-        'Console/Commands'    
-	),
+        'Console/Commands'
+    ),
 
-	/**
-	 * Multi-domain directory paths. If you want the translations in 
-	 * different files, just wrap your paths into a domain name. 
-	 * Paths on top-level will be associated to the default domain file, 
-	 * for example:
-	 */
-	/*'source-paths' => array(
+    /**
+     * Multi-domain directory paths. If you want the translations in
+     * different files, just wrap your paths into a domain name.
+     * Paths on top-level will be associated to the default domain file,
+     * for example:
+     */
+    /*'source-paths' => array(
 		'frontend' => array(
 			'controllers',
 			'views/frontend'
@@ -81,10 +81,9 @@ return array(
 		'storage/views'
 	),*/
 
-	/**
-	 * Sync laravel: A flag that determines if the laravel built-in locale must 
-	 * be changed when you call LaravelGettext::setLocale.
-	 */
-	'sync-laravel' => true,
-
+    /**
+     * Sync laravel: A flag that determines if the laravel built-in locale must
+     * be changed when you call LaravelGettext::setLocale.
+     */
+    'sync-laravel' => true,
 );

--- a/tests/config/config.php
+++ b/tests/config/config.php
@@ -4,99 +4,98 @@
 // return array(
 $testConfig = array(
 
-	/**
-	 * Default locale: this will be the default for your application. 
-	 * Is to be supposed that all strings are written in this language.
-	 */
-	'locale' => 'en_US',
+    /**
+     * Default locale: this will be the default for your application.
+     * Is to be supposed that all strings are written in this language.
+     */
+    'locale' => 'en_US',
 
-	/**
-	 * Supported locales: An array containing all allowed languages
-	 */
-	'supported-locales' => array(
-		'en_US',
-		'es_AR',
-		'de_DE'
-	),	
+    /**
+     * Supported locales: An array containing all allowed languages
+     */
+    'supported-locales' => array(
+        'en_US',
+        'es_AR',
+        'de_DE'
+    ),
 
-	/**
-	 * Default charset encoding.
-	 */
-	'encoding' => 'UTF-8',
+    /**
+     * Default charset encoding.
+     */
+    'encoding' => 'UTF-8',
 
-	/**
-	 * -----------------------------------------------------------------------
-	 * All standard configuration ends here. The following values 
-	 * are only for special cases.
-	 * -----------------------------------------------------------------------
-	 **/
+    /**
+     * -----------------------------------------------------------------------
+     * All standard configuration ends here. The following values
+     * are only for special cases.
+     * -----------------------------------------------------------------------
+     **/
 
-	/**
-	 * Base translation directory path relative to base-path 
-	 * (don't use trailing slash)
-	 */
-	'translations-path' => 'lang',	
+    /**
+     * Base translation directory path relative to base-path
+     * (don't use trailing slash)
+     */
+    'translations-path' => 'lang',
 
-	/**
-	 * Fallback locale: When default locale is not available
-	 */
-	'fallback-locale' => 'es_AR',
+    /**
+     * Fallback locale: When default locale is not available
+     */
+    'fallback-locale' => 'es_AR',
 
-	/**
-	 * Default domain used for translations: It is the file name for .po and .mo files
-	 */
-	'domain' => 'messages',
+    /**
+     * Default domain used for translations: It is the file name for .po and .mo files
+     */
+    'domain' => 'messages',
 
-	/**
-	 * Project name: is used on .po header files 
-	 */
-	'project' => 'MultilanguageLaravelApplication',
+    /**
+     * Project name: is used on .po header files
+     */
+    'project' => 'MultilanguageLaravelApplication',
 
-	/**
-	 * Translator contact data (used on .po headers too)
-	 */
-	'translator' => 'James Translator <james@translations.colm>',
+    /**
+     * Translator contact data (used on .po headers too)
+     */
+    'translator' => 'James Translator <james@translations.colm>',
 
-	/**
-	 * Paths where PoEdit will search recursively for strings to translate. 
-	 * All paths are relative to "base-path option" (don't use trailing slash).
-	 *
-	 * If you have already .po files with translations and the need to add 
-	 * another directory remember to call artisan gettext:update after do this.
-	 */
-	/*'source-paths' => array(
+    /**
+     * Paths where PoEdit will search recursively for strings to translate.
+     * All paths are relative to "base-path option" (don't use trailing slash).
+     *
+     * If you have already .po files with translations and the need to add
+     * another directory remember to call artisan gettext:update after do this.
+     */
+    /*'source-paths' => array(
 		'controllers',
 		'views',
 		'storage/views',
 	),*/
 
-	/**
-	 * Multidomain directory paths. If you want separate your translations in 
-	 * different files, just must wrap your paths into a domain name. 
-	 * Paths on top-level will be associated to the default domain file, 
-	 * for example:
-	 */
-	'source-paths' => array(
+    /**
+     * Multidomain directory paths. If you want separate your translations in
+     * different files, just must wrap your paths into a domain name.
+     * Paths on top-level will be associated to the default domain file,
+     * for example:
+     */
+    'source-paths' => array(
 
-		// Frontend example domain
-		'frontend' => array(
-			'controllers',
-			'views/frontend'
-		),
+        // Frontend example domain
+        'frontend' => array(
+            'controllers',
+            'views/frontend'
+        ),
 
-		// Backend example domain
-		'backend' => array(
-			'views/backend'
-		),
+        // Backend example domain
+        'backend' => array(
+            'views/backend'
+        ),
 
-		// Default domain
-		'views/misc'
-	),	
+        // Default domain
+        'views/misc'
+    ),
 
-	/**
-	 * Sync laravel: A flag that determines if the laravel built-in locale must 
-	 * be changed when you call LaravelGettext::setLocale.
-	 */
-	'sync-laravel' => true,
-
+    /**
+     * Sync laravel: A flag that determines if the laravel built-in locale must
+     * be changed when you call LaravelGettext::setLocale.
+     */
+    'sync-laravel' => true,
 );

--- a/tests/config/config.php
+++ b/tests/config/config.php
@@ -2,7 +2,12 @@
 
 // Used for testing
 // return array(
-$testConfig = array(
+return array(
+
+    /**
+     * Session identifier: Key under which the current locale will be stored.
+     */
+    'session-identifier' => 'laravel-gettext-locale',
 
     /**
      * Default locale: this will be the default for your application.

--- a/tests/controllers/ExampleController.php
+++ b/tests/controllers/ExampleController.php
@@ -1,9 +1,9 @@
-<?php 
+<?php
 
 class ExampleController
 {
-	public function __construct()
-	{
-		$translated = _("Controller string");
-	}
+    public function __construct()
+    {
+        $translated = _("Controller string");
+    }
 }

--- a/tests/unit/GettextTest.php
+++ b/tests/unit/GettextTest.php
@@ -8,92 +8,91 @@ use \Xinax\LaravelGettext\Config\ConfigManager;
 
 class GettextTest extends BaseTestCase
 {
-	/**
-	 * Gettext wrapper
-	 * @var Xinax\LaravelGettext\Gettext
-	 */
-	protected $gettext;
+    /**
+     * Gettext wrapper
+     * @var \Xinax\LaravelGettext\Gettext
+     */
+    protected $gettext;
 
     public function setUp()
-	{
-		parent::setUp();
+    {
+        parent::setUp();
 
         // Config
         include __DIR__ . '/../config/config.php';
         $config = ConfigManager::create($testConfig);
 
-		// Session handler
-		$session = m::mock('Xinax\LaravelGettext\Session\SessionHandler');
-		$session->shouldReceive('get')->andReturn('en_US');
-		$session->shouldReceive('set')->with('en_US');
+        // Session handler
+        $session = m::mock('Xinax\LaravelGettext\Session\SessionHandler');
+        $session->shouldReceive('get')->andReturn('en_US');
+        $session->shouldReceive('set')->with('en_US');
 
-		// Framework adapter
-		$adapter = m::mock('Xinax\LaravelGettext\Adapters\LaravelAdapter');
-		$adapter->shouldReceive('setLocale')->with('en_US');
-		$adapter->shouldReceive('getApplicationPath')->andReturn(dirname(__FILE__));
+        // Framework adapter
+        $adapter = m::mock('Xinax\LaravelGettext\Adapters\LaravelAdapter');
+        $adapter->shouldReceive('setLocale')->with('en_US');
+        $adapter->shouldReceive('getApplicationPath')->andReturn(dirname(__FILE__));
 
         // FileSystem module
         $fileSystem = m::mock('Xinax\LaravelGettext\FileSystem');
         $fileSystem->shouldReceive('filesystemStructure')->andReturn(true);
         $fileSystem->shouldReceive('getDomainPath')->andReturn('path');
 
-		$this->gettext = new Gettext($config->get(), $session, $adapter, $fileSystem);
+        $this->gettext = new Gettext($config->get(), $session, $adapter, $fileSystem);
 
-	}
+    }
 
     /**
      * Test setting locale.
      */
-	public function testSetLocale()
-	{
-		$response = $this->gettext->setLocale('en_US');
+    public function testSetLocale()
+    {
+        $response = $this->gettext->setLocale('en_US');
 
         $this->assertEquals('en_US', $response);
-	}
+    }
 
     /**
      * Test getting locale.
      * It should receive locale from mocked config.
      */
-	public function testGetLocale()
-	{
-		$response = $this->gettext->getLocale();
+    public function testGetLocale()
+    {
+        $response = $this->gettext->getLocale();
 
-		$this->assertEquals('en_US', $response);
-	}
+        $this->assertEquals('en_US', $response);
+    }
 
-	public function testIsLocaleSupported()
-	{
-		$this->assertTrue($this->gettext->isLocaleSupported('en_US'));
-	}
+    public function testIsLocaleSupported()
+    {
+        $this->assertTrue($this->gettext->isLocaleSupported('en_US'));
+    }
 
     /**
      * Test dumping locale to string
      */
-	public function testToString()
-	{
-		$response = $this->gettext->__toString();
+    public function testToString()
+    {
+        $response = $this->gettext->__toString();
 
-		$this->assertEquals('en_US', $response);
-	}
+        $this->assertEquals('en_US', $response);
+    }
 
-	public function testGetEncoding()
-	{
-		$response = $this->gettext->getEncoding();
-		$this->assertNotEmpty($response);
-		$this->assertEquals('UTF-8', $response);
-	}
+    public function testGetEncoding()
+    {
+        $response = $this->gettext->getEncoding();
+        $this->assertNotEmpty($response);
+        $this->assertEquals('UTF-8', $response);
+    }
 
-	public function testSetEncoding()
-	{
-		$response = $this->gettext->setEncoding('UTF-8');
-		$this->assertNotEmpty($response);
-		$this->assertInstanceOf('Xinax\LaravelGettext\Gettext', $response);
-	}
+    public function testSetEncoding()
+    {
+        $response = $this->gettext->setEncoding('UTF-8');
+        $this->assertNotEmpty($response);
+        $this->assertInstanceOf('Xinax\LaravelGettext\Gettext', $response);
+    }
 
-	public function tearDown()
-	{
-		m::close();
-	}
-
+    public function tearDown()
+    {
+        m::close();
+    }
 }

--- a/tests/unit/GettextTest.php
+++ b/tests/unit/GettextTest.php
@@ -19,7 +19,7 @@ class GettextTest extends BaseTestCase
         parent::setUp();
 
         // Config
-        include __DIR__ . '/../config/config.php';
+        $testConfig = include __DIR__ . '/../config/config.php';
         $config = ConfigManager::create($testConfig);
 
         // Session handler

--- a/tests/unit/LaravelGettextTest.php
+++ b/tests/unit/LaravelGettextTest.php
@@ -5,7 +5,6 @@ namespace Xinax\LaravelGettext\Test;
 use \Mockery as m;
 use \Xinax\LaravelGettext\LaravelGettext;
 
-
 class LaravelGettextTest extends BaseTestCase
 {
     /**
@@ -78,6 +77,4 @@ class LaravelGettextTest extends BaseTestCase
     {
         $this->assertEquals('en_US', $this->laravelGettext->getLocale());
     }
-
 }
-

--- a/tests/unit/MultipleDomainTest.php
+++ b/tests/unit/MultipleDomainTest.php
@@ -227,5 +227,4 @@ class MultipleDomainTest extends BaseTestCase
         $dir = __DIR__ . '/../lang/i18n';
         FileSystem::clearDirectory($dir);
     }
-
 }

--- a/tests/unit/MultipleDomainTest.php
+++ b/tests/unit/MultipleDomainTest.php
@@ -57,7 +57,7 @@ class MultipleDomainTest extends BaseTestCase
         parent::setUp();
 
         // $testConfig array
-        include __DIR__ . '/../config/config.php';
+        $testConfig = include __DIR__ . '/../config/config.php';
         $this->configManager = ConfigManager::create($testConfig);
 
         $this->basePath = realpath(__DIR__ . '/..');


### PR DESCRIPTION
I made the session identifier configurable and also some improvements related to the coding standard of this package.

Tests are still running and my changes should not brake any existing installations as by default the session identifier "laravel-gettext-locale" will be taken.