### PR TITLE
locale begin to change after this and all tests pass successfully

### DIFF
--- a/src/Xinax/LaravelGettext/Gettext.php
+++ b/src/Xinax/LaravelGettext/Gettext.php
@@ -89,6 +89,7 @@ class Gettext
             // All locale functions are updated: LC_COLLATE, LC_CTYPE,
             // LC_MONETARY, LC_NUMERIC, LC_TIME and LC_MESSAGES
             putenv("LC_ALL=$gettextLocale");
+            putenv("LANGUAGE=$gettextLocale");
             setlocale(LC_ALL, $gettextLocale);
 
             // Domain


### PR DESCRIPTION
Due to same problem as described here:
http://php.net/manual/en/ref.gettext.php#68853
I made such changes.

1. I use full name of locale (en_US).
2. I have correctly installed this locale on my local machine (and it is applied system-wide).
However, phpunit tests failed on my machine. After this changes - everything is Ok.