### PR TITLE
Lets keep peoples git repos clean after a update

### DIFF
--- a/src/Xinax/LaravelGettext/FileSystem.php
+++ b/src/Xinax/LaravelGettext/FileSystem.php
@@ -210,7 +210,7 @@ class FileSystem
      */
     protected function createDirectory($path)
     {
-        if (!mkdir($path)) {
+        if (!file_exists($path) && !mkdir($path)) {
             throw new FileCreationException(
                 sprintf('Can\'t create the directory: %s', $path)
             );
@@ -549,11 +549,15 @@ class FileSystem
         );
 
         foreach ($files as $fileinfo) {
-            $todo = ($fileinfo->isDir() ? 'rmdir' : 'unlink');
-            $todo($fileinfo->getRealPath());
+            // if the file isn't a .gitignore file we should remove it.
+            if($fileinfo->getFilename() !== '.gitignore'){
+                $todo = ($fileinfo->isDir() ? 'rmdir' : 'unlink');
+                $todo($fileinfo->getRealPath());
+            }
         }
-
-        rmdir($path);
+        
+        // since the folder now contains a .gitignore we can't remove it
+        //rmdir($path);
         return true;
     }
 


### PR DESCRIPTION
Instead of just removing the directory we should check if the folder exists and not destroy it.

This is so people who are running a local vagrant setup doesn't have to readd the .gitignore every time ;)