### PR TITLE
Added the 'adapter' config option

### DIFF
--- a/src/Xinax/LaravelGettext/Config/ConfigManager.php
+++ b/src/Xinax/LaravelGettext/Config/ConfigManager.php
@@ -90,6 +90,8 @@ class ConfigManager
 
         $id = isset($config['session-identifier']) ? $config['session-identifier'] : 'laravel-gettext-locale';
 
+        $adapter = isset($config['adapter']) ? $config['adapter'] : \Xinax\LaravelGettext\Adapters\LaravelAdapter::class;
+
         $container->setLocale($config['locale'])
             ->setSessionIdentifier($id)
             ->setEncoding($config['encoding'])
@@ -100,7 +102,8 @@ class ConfigManager
             ->setProject($config['project'])
             ->setTranslator($config['translator'])
             ->setSourcePaths($config['source-paths'])
-            ->setSyncLaravel($config['sync-laravel']);
+            ->setSyncLaravel($config['sync-laravel'])
+            ->setAdapter($adapter);
 
         if (array_key_exists('relative-path', $config)) {
             $container->setRelativePath($config['relative-path']);

--- a/src/Xinax/LaravelGettext/Config/Models/Config.php
+++ b/src/Xinax/LaravelGettext/Config/Models/Config.php
@@ -82,6 +82,13 @@ class Config
     protected $syncLaravel;
 
     /**
+     * The adapter class used to sync with laravel locale
+     *
+     * @var string
+     */
+    protected $adapter;
+
+    /**
      * Custom locale name
      * Used when needed locales are unavalilable
      *
@@ -327,6 +334,26 @@ class Config
     public function setSyncLaravel($syncLaravel)
     {
         $this->syncLaravel = $syncLaravel;
+        return $this;
+    }
+
+    /**
+     * Gets the adapter class.
+     *
+     * @return string
+     */
+    public function getAdapter()
+    {
+        return $this->adapter;
+    }
+
+    /**
+     * @param string $adapter
+     * @return $this
+     */
+    public function setAdapter($adapter)
+    {
+        $this->adapter = $adapter;
         return $this;
     }
 

--- a/src/Xinax/LaravelGettext/LaravelGettextServiceProvider.php
+++ b/src/Xinax/LaravelGettext/LaravelGettextServiceProvider.php
@@ -40,22 +40,23 @@ class LaravelGettextServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $configuration = Config\ConfigManager::create();
+
         $this->app->bind(
             'Adapters/AdapterInterface',
-            'Adapters/LaravelAdapter'
+            $configuration->get()->getAdapter()
         );
 
         // Main class register
-        $this->app['laravel-gettext'] = $this->app->share(function ($app) {
-
-            $configuration = Config\ConfigManager::create();
+        $this->app['laravel-gettext'] = $this->app->share(function ($app) use ($configuration) {
 
             $fileSystem = new FileSystem($configuration->get(), app_path(), storage_path());
 
+            $adapter = $configuration->get()->getAdapter();
             $gettext = new Gettext(
                 $configuration->get(),
                 new Session\SessionHandler($configuration->get()->getSessionIdentifier()),
-                new Adapters\LaravelAdapter,
+                new $adapter,
                 $fileSystem
             );
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -99,6 +99,11 @@ return [
     'sync-laravel' => true,
 
     /**
+     * The adapter used to sync the laravel built-in locale
+     */
+    'adapter' => \Xinax\LaravelGettext\Adapters\LaravelAdapter::class,
+
+    /**
      * Use custom locale that is not supported by the system
      */
     'custom-locale' => false,


### PR DESCRIPTION
This allows the developer to supply a custom adapter to override the default `App::setLocale(substr($locale, 0, 2));` function.
I made the option backwards compatible to the config will automatically load `Xinax\LaravelGettext\Adapters\LaravelAdapter` if the `adapter` config is missing.