### PR TITLE
Fixed #81

### DIFF
--- a/src/Xinax/LaravelGettext/Config/Models/Config.php
+++ b/src/Xinax/LaravelGettext/Config/Models/Config.php
@@ -364,19 +364,15 @@ class Config
      */
     public function getAllDomains()
     {
-        $domains = [
-            $this->domain
-        ];
-
-        $userDomains = [];
+        $domains = [$this->domain]; // add the default domain
 
         foreach ($this->sourcePaths as $domain => $paths) {
             if (is_array($paths)) {
-                array_push($userDomains, $domain);
+                array_push($domains, $domain);
             }
         }
 
-        return array_merge($domains, $userDomains);
+        return array_unique($domains);
     }
 
     /**
@@ -387,23 +383,27 @@ class Config
      */
     public function getSourcesFromDomain($domain)
     {
-        if ($domain == $this->domain) {
-            $rootPaths = [];
+        // grab any paths wrapped in $domain
+        $explicitPaths = array_key_exists($domain, $this->sourcePaths) ? $this->sourcePaths[$domain] : [];
 
-            foreach ($this->sourcePaths as $domain => $path) {
+        // if we're not including the default domain, return what we have so far
+        if ($this->domain != $domain) {
+            return $explicitPaths;
+        }
+
+        // otherwise, grab all the default domain paths
+        // and merge them with paths wrapped in $domain
+        return array_reduce(
+            $this->sourcePaths,
+            function ($carry, $path) {
                 if (!is_array($path)) {
-                    array_push($rootPaths, $path);
+                    $carry[] = $path;
                 }
-            }
 
-            return $rootPaths;
-        }
-
-        if (array_key_exists($domain, $this->sourcePaths)) {
-            return $this->sourcePaths[$domain];
-        }
-
-        return [];
+                return $carry;
+            },
+            $explicitPaths
+        );
     }
 
     /**

--- a/tests/config/config.php
+++ b/tests/config/config.php
@@ -99,8 +99,13 @@ return array(
             'views/backend'
         ),
 
+        // messages domain
+        'messages' => [
+            'views/messages'
+        ],
+
         // default domain (messages)
-        'views/misc'
+        'views/misc',
     ),
 
     /**

--- a/tests/config/config.php
+++ b/tests/config/config.php
@@ -88,18 +88,18 @@ return array(
      */
     'source-paths' => array(
 
-        // Frontend example domain
+        // frontend domain
         'frontend' => array(
             'controllers',
             'views/frontend'
         ),
 
-        // Backend example domain
+        // backend domain
         'backend' => array(
             'views/backend'
         ),
 
-        // Default domain
+        // default domain (messages)
         'views/misc'
     ),
 

--- a/tests/unit/BaseTestCase.php
+++ b/tests/unit/BaseTestCase.php
@@ -2,8 +2,10 @@
 
 namespace Xinax\LaravelGettext\Test;
 
-use \Mockery as m;
+use Mockery as m;
+use PHPUnit_Framework_TestCase;
 
-abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
+abstract class BaseTestCase extends PHPUnit_Framework_TestCase
 {
+
 }

--- a/tests/unit/MultipleDomainTest.php
+++ b/tests/unit/MultipleDomainTest.php
@@ -107,6 +107,7 @@ class MultipleDomainTest extends BaseTestCase
     public function testDefaultDomainPaths()
     {
         $expectedPaths = [
+            'views/messages',
             'views/misc'
         ];
 

--- a/tests/unit/MultipleDomainTest.php
+++ b/tests/unit/MultipleDomainTest.php
@@ -2,14 +2,13 @@
 
 namespace Xinax\LaravelGettext\Test;
 
-use \RecursiveIteratorIterator;
-use \RecursiveDirectoryIterator;
-use \Mockery as m;
-use \Xinax\LaravelGettext\LaravelGettext;
-use \Xinax\LaravelGettext\Gettext;
-use \Xinax\LaravelGettext\FileSystem;
-use \Xinax\LaravelGettext\Config\ConfigManager;
-use Xinax\LaravelGettext\Exceptions\UndefinedDomainException;
+use Mockery as m;
+use Xinax\LaravelGettext\Adapters\LaravelAdapter;
+use Xinax\LaravelGettext\Config\ConfigManager;
+use Xinax\LaravelGettext\FileSystem;
+use Xinax\LaravelGettext\Gettext;
+use Xinax\LaravelGettext\LaravelGettext;
+use Xinax\LaravelGettext\Session\SessionHandler;
 
 /**
  * Class MultipleDomainTest
@@ -80,25 +79,44 @@ class MultipleDomainTest extends BaseTestCase
             'backend',
         ];
 
-        $result = $this->configManager->get()->getAllDomains();
-        $this->assertTrue($result === $expected);
+        $actual = $this->configManager->get()->getAllDomains();
+        $this->assertEquals($expected, $actual);
+    }
 
-    }    
-
-    public function testDomainPaths()
+    public function testFrontendDomainPaths()
     {
-        $expected = [
+        $expectedPaths = [
             'controllers',
             'views/frontend'
         ];
 
-        $result = $this->configManager->get()->getSourcesFromDomain('frontend');
-        $this->assertTrue($result === $expected);
+        $actualPaths = $this->configManager->get()->getSourcesFromDomain('frontend');
+        $this->assertEquals($expectedPaths, $actualPaths);
+    }
 
-        $expected = [ 'views/misc' ];
-        $result = $this->configManager->get()->getSourcesFromDomain('messages');
-        $this->assertTrue($result === $expected);
+    public function testBackendDomainPaths()
+    {
+        $expectedPaths = [
+            'views/backend'
+        ];
 
+        $actualPaths = $this->configManager->get()->getSourcesFromDomain('backend');
+        $this->assertEquals($expectedPaths, $actualPaths);
+    }
+
+    public function testDefaultDomainPaths()
+    {
+        $expectedPaths = [
+            'views/misc'
+        ];
+
+        $actualPaths = $this->configManager->get()->getSourcesFromDomain('messages');
+        $this->assertEquals($expectedPaths, $actualPaths);
+    }
+
+    public function testNoMissingDomainPaths()
+    {
+        // config/config.php doesn't contain a domain named `missing`, and should return no records
         $this->assertCount(0, $this->configManager->get()->getSourcesFromDomain('missing'));
     }
 
@@ -163,14 +181,14 @@ class MultipleDomainTest extends BaseTestCase
     public function testTranslations()
     {
         /** @var \Xinax\LaravelGettext\Session\SessionHandler|\Mockery\MockInterface $session */
-        $session = m::mock('Xinax\LaravelGettext\Session\SessionHandler');
+        $session = m::mock(SessionHandler::class);
         $session->shouldReceive('get')
             ->andReturn('es_AR');
 
         $session->shouldReceive('set');
 
         /** @var \Xinax\LaravelGettext\Adapters\LaravelAdapter|\Mockery\MockInterface $adapter */
-        $adapter = m::mock('Xinax\LaravelGettext\Adapters\LaravelAdapter');
+        $adapter = m::mock(LaravelAdapter::class);
 
         $adapter->shouldReceive('setLocale');
         $adapter->shouldReceive('getApplicationPath')


### PR DESCRIPTION
`getSourcesFromDomain` now handles sections matching default domain correctly (see #81)

```
'source-paths' => [

    // now included in default-domain
    'default-domain' => [
        'first/default-domain/path',
        'second/default-domain/path'
    ],

    // included in default-domain
    'third/default-domain/path'
    'fourth/default-domain/path'
],
```