### PR TITLE
fixed: vsprintf(): Too few arguments

### DIFF
--- a/src/Xinax/LaravelGettext/Support/helpers.php
+++ b/src/Xinax/LaravelGettext/Support/helpers.php
@@ -15,11 +15,14 @@ if (!function_exists('__')) {
         $translation = $translator->translate($message);
 
         if (strlen($translation)) {
-            if (!empty($args) && !is_array($args)) {
-                $args = array_slice(func_get_args(), 1);
+            if (!empty($args)) {
+                if(!is_array($args)) {
+                    $args = array_slice(func_get_args(), 1);
+                }
+                $translation = vsprintf($translation, $args);
             }
-            $translation = vsprintf($translation, $args);
-            return $translation;    
+
+            return $translation;
         }
 
         /**


### PR DESCRIPTION
Fixed:

`echo __('100% translated string'); `

> ErrorException in helpers.php line 21: vsprintf(): Too few arguments